### PR TITLE
Foi adicionado um proxy para o servidor do back-end

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -72,7 +72,11 @@
               "browserTarget": "oportunia-frontend:build:development"
             }
           },
-          "defaultConfiguration": "development"
+          "defaultConfiguration": "development",
+          "options": {
+              "browserTarget": "oportunia-frontend:build",
+              "proxyConfig": "src/proxy.conf.json"
+          }
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",

--- a/src/app/services/login.service.ts
+++ b/src/app/services/login.service.ts
@@ -4,7 +4,7 @@ import { Observable } from "rxjs";
 import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 
-const baseurl = "http://localhost:8080/api/";
+const baseurl = "/api/";
 @Injectable({
   providedIn: "root",
 })

--- a/src/app/services/mentee.service.ts
+++ b/src/app/services/mentee.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 
-const baseurl = "http://localhost:8080/api/mentors";
+const baseurl = "/api/mentors";
 
 @Injectable({
   providedIn: "root",

--- a/src/app/services/mentores.service.ts
+++ b/src/app/services/mentores.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from "@angular/core";
 import { Observable } from "rxjs";
 import { MentorInterface, MentorModel } from "../models/mentores-model";
 
-const baseurl = "http://localhost:8080/api/mentors";
+const baseurl = "/api/mentors";
 
 @Injectable({
   providedIn: "root",

--- a/src/app/services/mentorias.service.ts
+++ b/src/app/services/mentorias.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from "@angular/core";
 import { Observable } from "rxjs";
 import { MentoriaInterface, MentoriaModel } from "../models/mentorias-model";
 
-const baseurl = "http://localhost:8080/api/mentorias";
+const baseurl = "/api/mentorias";
 
 @Injectable({
   providedIn: "root",

--- a/src/proxy.conf.json
+++ b/src/proxy.conf.json
@@ -1,0 +1,6 @@
+{
+    "/api/*":{
+        "target":"http://localhost:8080/",
+        "secure":false
+    }
+}


### PR DESCRIPTION
Todos os requests para /api/* são redirecionados ao servidor do back-end (atualmente localhost:8080).

Isso é vantajoso por motivos de [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS): quando o cliente apenas faz requests a um servidor, não é necessário autorizar o cliente a fazer requests a outros servidor.