### PR TITLE
add: marcar mentoria com nome dos usuários

### DIFF
--- a/src/app/mentores/mentores/mentores.component.html
+++ b/src/app/mentores/mentores/mentores.component.html
@@ -34,7 +34,7 @@
         <button
           mat-button
           color="primary"
-          (click)="modal.toggle()"
+          (click)="modal.toggle(mentor.first_name)"
           class="action"
         >
           Marcar mentoria!
@@ -73,7 +73,7 @@
   <button
     mat-button
     color="primary"
-    (click)="modal.sendAndToggle();"
+    (click)="modal.sendAndToggle(userService);"
     class="btn-primary">Enviar solicitação</button>
 
   <button

--- a/src/app/mentores/mentores/mentores.component.ts
+++ b/src/app/mentores/mentores/mentores.component.ts
@@ -19,7 +19,7 @@ export class MentoresComponent {
 
   constructor(
     private mentorService: MentoresService,
-    private userService: UserService
+    public userService: UserService
   ) {
 
     this.mentorService.getMentores().subscribe((mentors) => {
@@ -34,7 +34,7 @@ export class MentoresComponent {
 
   onButtonClick(mentor: any) {
     console.log(this.userService.getUser());
-    console.log(`${mentor} selecionado`);
+    console.log(`${mentor.email} selecionado`);
   }
 
   applyFilter(event: Event) {

--- a/src/app/mentores/mentores/modal/modal.component.html
+++ b/src/app/mentores/mentores/modal/modal.component.html
@@ -2,6 +2,6 @@
     <div class="modal">
       <ng-content></ng-content>
     </div>
-    <div (click)="toggle()"
+    <div (click)="toggle('')"
          class="overlay"></div>
   </ng-container>

--- a/src/app/mentores/mentores/modal/modal.component.ts
+++ b/src/app/mentores/mentores/modal/modal.component.ts
@@ -1,19 +1,22 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, Inject } from '@angular/core';
 import { MentoriaModel } from "../../../models/mentorias-model";
 import { MentoriasService } from "../../../services/mentorias.service";
 import { MatSnackBar } from "@angular/material/snack-bar";
 import { Router } from "@angular/router";
 import { FormBuilder } from '@angular/forms';
+import { UserService } from 'src/app/services/user.service';
 
 @Component({
   selector: 'app-modal',
   templateUrl: './modal.component.html',
-  styleUrls: ['./modal.component.scss']
+  styleUrls: ['./modal.component.scss'],
+  providers: [UserService]
 })
 export class ModalComponent {
   show: boolean = false;
   @Input() mentoria: any;
   newMentoria: MentoriaModel = new MentoriaModel("", "", "", "", "");
+  mentorName: String = '';
 
   constructor(private formBuilder: FormBuilder, private mentoriaService: MentoriasService, 
     private snackBar: MatSnackBar, private router: Router) {
@@ -24,15 +27,14 @@ export class ModalComponent {
     })
   }
 
-  toggle() {
+  toggle(mentorName: String) {
     this.show = !this.show;
+    this.mentorName = mentorName;
   }
 
-  sendAndToggle() {
-    console.log(this.mentoria.value.duracao);
-    console.log(this.mentoria.value.formato);
-    console.log(this.mentoria.value.recompensa);
-    this.newMentoria = new MentoriaModel("teste mentor", "teste mentorado", this.mentoria.value.duracao, 
+  sendAndToggle(user: UserService) {
+    console.log(this.mentorName);
+    this.newMentoria = new MentoriaModel(this.mentorName, user.getUser()!.first_name, this.mentoria.value.duracao, 
     this.mentoria.value.formato, this.mentoria.value.recompensa);
     this.mentoriaService.createMentoria(this.newMentoria).subscribe(() =>
       this.snackBar.open("Mentoria solicitada!", "Dismiss", {
@@ -43,11 +45,11 @@ export class ModalComponent {
       .navigate([""], { skipLocationChange: true })
       .then(() => this.router.navigate(["/mentorias"]));
     this.mentoria.reset();
-    this.toggle();
+    this.toggle('');
   }
 
   deleteAndToggle() {
     this.mentoria.reset();
-    this.toggle();
+    this.toggle('');
   }
 }


### PR DESCRIPTION
Ao logar como mentorado é possível marcar uma mentoria que vai pegar o nome do usuário logado + o nome do mentor selecionado. Só tem que ver a questão da sessão ficar mantida com refresh.